### PR TITLE
Move searched item back to top of the recents list if selected again

### DIFF
--- a/src/recentFiles.ts
+++ b/src/recentFiles.ts
@@ -21,10 +21,14 @@ export default class RecentFiles {
   }
 
   addFile(filePath: string) {
-    if (!this.includes(filePath)) {
+    const existing = this.recentFiles.find(result => result.filePath === filePath);
+    if (existing) {
+      this.recentFiles = this.recentFiles.filter(result => result !== existing);
+      this.recentFiles.unshift(existing);
+    } else {
       this.recentFiles.unshift({key:this.invertFilePath(filePath), filePath: filePath});
-      this.workspaceState.update('recents', this.recentFiles);
     }
+    this.workspaceState.update('recents', this.recentFiles);
   }
 
   includes(filePath: string) {


### PR DESCRIPTION
If the user selects an item that was already previously added to the recentFiles list, this will move that file back to the top of the list.

The idea is that when showing the list of recent files, it should be sorted by the most recents on top.