### PR TITLE
Show hidden files and folders, but keep ignoring .git

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -34,7 +34,7 @@ function getFzfPath(): string {
 function buildSearch(fd: string, fzf: string, text: string): string {
   const path = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.path;
 
-  return text ? `${fd} --type f . '${path || ''}' | ${fzf} --tiebreak=end -m -f '${text}'\n` : '';
+  return text ? `${fd} -H --exclude '.git' --type f . '${path || ''}' | ${fzf} --tiebreak=end -m -f '${text}'\n` : '';
 }
 
 export default class Search {


### PR DESCRIPTION
This PR is an attempt at #5 

`fd` has a `-H` flag that will include hidden files and folders, but there is no option for ONLY allowing hidden files (and not hidden folders).

As a result, if we add `-H`, it is possible to search for hidden files like `.eslintrc` or `.gitignore`, but it will also show *A LOT* of files hidden inside the `.git` folder.

As a compromise, this PR enables "include hidden files and folders" but explicitly excludes the `.git` folder.

It would make sense to also exclude hidden folders from other popular version control systems, but since `fd` itself is opinionated to Git (it automatically ignores files in `.gitignore`, for example), this PR only ignores the `.git` folder.